### PR TITLE
Fix Undefined index: code

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -174,8 +174,8 @@ class Apple extends AbstractProvider
     {
         if ($response->getStatusCode() >= 400) {
             throw new AppleAccessDeniedException(
-                $data['error'] ?: $response->getReasonPhrase(),
-                $data['code'] ?: $response->getStatusCode(),
+                isset($data['error']) ? $data['error'] : $response->getReasonPhrase(),
+                isset($data['code']) ? $data['code'] : $response->getStatusCode(),
                 $response
             );
         }


### PR DESCRIPTION
If request fails and Apple API return only an error index in data array, in checkResponse method it throws undefined index code.