### PR TITLE
Replace fproject/php-jwt with firebase/php-jwt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "league/oauth2-client": "^2.0",
         "ext-json": "*",
-        "fproject/php-jwt": "^4.0",
+        "firebase/php-jwt": "^5.0",
         "lcobucci/jwt": "^3.3"
     },
     "require-dev": {

--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -82,7 +82,7 @@ class AppleAccessToken extends AccessToken
      */
     protected function getAppleKey()
     {
-        return JWK::parseKeySet(file_get_contents('https://appleid.apple.com/auth/keys'));
+        return JWK::parseKeySet(json_decode(file_get_contents('https://appleid.apple.com/auth/keys'), true));
     }
 
     /**


### PR DESCRIPTION
Both fproject/php-jwt and firebase/php-jwt use the same namespace: Firebase\JWT.

When using another library that depends on firebase/php-jwt (for example: league/oauth2-google) there will be a conflict and the call JWK::parseKeySet(...) in src/Token/AppleAccessToken.php will fail because the method definition from firebase/php-jwt does not accept a string as parameter.

This issue has been reported here: #5 

To fix this I've replaced the fproject/php-jwt dependency with firebase/php-jwt and I've update the  parameter for the JWK::parseKeySet(...) call to be a string.

firebase/php-jwt and fproject/php-jwt seem to be almost identical and firebase/php-jwt seems to still be maintained. 

Unit testing passed successfuly, but I don't know for sure if there are any other ripple effects.