### PR TITLE
Fix class JWK not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "league/oauth2-client": "^2.0",
         "ext-json": "*",
-        "firebase/php-jwt": "^5.0",
+        "firebase/php-jwt": "^5.2",
         "lcobucci/jwt": "^3.3"
     },
     "require-dev": {


### PR DESCRIPTION
Class `JWK` was only introduced in version 5.2.0 of package `firebase/php-jwt`