### PR TITLE
Check if name scope is set before trying to return firstName or lastName

### DIFF
--- a/src/Provider/AppleResourceOwner.php
+++ b/src/Provider/AppleResourceOwner.php
@@ -46,7 +46,11 @@ class AppleResourceOwner extends GenericResourceOwner
      */
     public function getFirstName()
     {
-        return $this->getAttribute('name')['firstName'];
+        $name = $this->getAttribute('name');
+        if (isset($name)) {
+            return $name['firstName'];
+        }
+        return null;
     }
 
     /**
@@ -66,7 +70,11 @@ class AppleResourceOwner extends GenericResourceOwner
      */
     public function getLastName()
     {
-        return $this->getAttribute('name')['lastName'];
+        $name = $this->getAttribute('name');
+        if (isset($name)) {
+            return $name['lastName'];
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
When you try to access firstName or lastName second time, it throws an exception `Notice: Trying to access array offset on value of type null` instead of returning null. This PR fixes that.