### PR TITLE
Use guzzle http client instead of file_get_contents

### DIFF
--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -88,7 +88,7 @@ class AppleAccessToken extends AccessToken
         $request = $client->get('https://appleid.apple.com/auth/keys');
         $response = $request->getBody();
 
-        if($response){
+        if ($response) {
             return JWK::parseKeySet(json_decode($response, true));
         }
         return false;

--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -84,7 +84,14 @@ class AppleAccessToken extends AccessToken
      */
     protected function getAppleKey()
     {
-        return JWK::parseKeySet(json_decode(file_get_contents('https://appleid.apple.com/auth/keys'), true));
+        $client = new \GuzzleHttp\Client();
+        $request = $client->get('https://appleid.apple.com/auth/keys');
+        $response = $request->getBody();
+
+        if($response){
+            return JWK::parseKeySet(json_decode($response, true));
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Many servers have allow_url_fopen disabled so they cant use file_get_contents to load apple keys.