### PR TITLE
use guzzle instance from AbstractProvider to get apple auth keys

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -76,7 +76,7 @@ class Apple extends AbstractProvider
      */
     protected function createAccessToken(array $response, AbstractGrant $grant)
     {
-        return new AppleAccessToken($response);
+        return new AppleAccessToken($response, $this->getHttpClient());
     }
 
     /**

--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -4,6 +4,7 @@ namespace League\OAuth2\Client\Token;
 
 use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
+use GuzzleHttp\ClientInterface;
 use InvalidArgumentException;
 
 class AppleAccessToken extends AccessToken
@@ -24,6 +25,11 @@ class AppleAccessToken extends AccessToken
     protected $isPrivateEmail;
 
     /**
+     * @var ClientInterface
+     */
+    protected $httpClient;
+
+    /**
      * Constructs an access token.
      *
      * @param array $options An array of options returned by the service provider
@@ -32,8 +38,10 @@ class AppleAccessToken extends AccessToken
      *
      * @throws \Exception
      */
-    public function __construct(array $options = [])
+    public function __construct(array $options = [], $httpClient)
     {
+        $this->httpClient = $httpClient;
+
         if (array_key_exists('refresh_token', $options)) {
             if (empty($options['id_token'])) {
                 throw new InvalidArgumentException('Required option not passed: "id_token"');
@@ -84,7 +92,9 @@ class AppleAccessToken extends AccessToken
      */
     protected function getAppleKey()
     {
-        return JWK::parseKeySet(json_decode(file_get_contents('https://appleid.apple.com/auth/keys'), true));
+        $response = $this->httpClient->request('GET', 'https://appleid.apple.com/auth/keys');
+
+        return JWK::parseKeySet(json_decode($response->getBody()->getContents(), true));
     }
 
     /**

--- a/test/src/Token/AppleAccessTokenTest.php
+++ b/test/src/Token/AppleAccessTokenTest.php
@@ -2,6 +2,8 @@
 
 namespace League\OAuth2\Client\Test\Token;
 
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
 use League\OAuth2\Client\Token\AppleAccessToken;
 use PHPUnit\Framework\TestCase;
 use Mockery as m;
@@ -39,7 +41,7 @@ class AppleAccessTokenTest extends TestCase
             'expires_in' => 3600,
             'refresh_token' => 'abc.0.def',
             'id_token' => 'something'
-        ]);
+        ], $this->getClient(1));
         $this->assertEquals('something', $accessToken->getIdToken());
         $this->assertEquals('123.abc.123', $accessToken->getResourceOwnerId());
         $this->assertEquals('access_token', $accessToken->getToken());
@@ -51,7 +53,21 @@ class AppleAccessTokenTest extends TestCase
             'access_token' => 'access_token',
             'token_type' => 'Bearer',
             'expires_in' => 3600
-        ]);
+        ], $this->getClient(0));
         $this->assertEquals('access_token', $refreshToken->getToken());
+    }
+
+    private function getClient($times)
+    {
+        $client = m::mock('GuzzleHttp\ClientInterface');
+        if ($times > 0) {
+            $client->shouldReceive('request')
+                ->times($times)
+                ->withArgs(['GET', 'https://appleid.apple.com/auth/keys'])
+                ->andReturn(new Response())
+            ;
+        }
+
+        return $client;
     }
 }


### PR DESCRIPTION
as another PR mentioned many environments have file_get_contents disabled