### PR TITLE
Fix BC-break for combination of PHP 7.4 and lcobucci/jwt 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,23 @@ language: php
 matrix:
     include:
         - php: 5.6
+          env: LCOBUCCI_JWT_VERSION=^3.4
         - php: 7.0
+          env: LCOBUCCI_JWT_VERSION=^3.4
         - php: 7.1
+          env: LCOBUCCI_JWT_VERSION=^3.4
         - php: 7.2
+          env: LCOBUCCI_JWT_VERSION=^3.4
         - php: 7.3
+          env: LCOBUCCI_JWT_VERSION=^3.4
         - php: 7.4
+          env: LCOBUCCI_JWT_VERSION=^3.4
+        - php: 7.4
+          env: LCOBUCCI_JWT_VERSION=^4.0
         - php: 8.0
+          env: LCOBUCCI_JWT_VERSION=^4.0
         - php: nightly
+          env: LCOBUCCI_JWT_VERSION=^4.0
         - php: hhvm-3.6
           sudo: required
           dist: trusty
@@ -41,6 +51,7 @@ matrix:
 
 before_script:
   - travis_retry composer self-update
+  - travis_retry composer require lcobucci/jwt $LCOBUCCI_JWT_VERSION
   - travis_retry composer install --no-interaction --prefer-source --dev
   - travis_retry phpenv rehash
 

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -237,10 +237,17 @@ class Apple extends AbstractProvider
      */
     public function getConfiguration()
     {
-        return Configuration::forSymmetricSigner(
-            Signer\Ecdsa\Sha256::create(),
-            $this->getLocalKey()
-        );
+        if (method_exists(Signer\Ecdsa\Sha256::class, 'create')) {
+            return Configuration::forSymmetricSigner(
+                Signer\Ecdsa\Sha256::create(),
+                $this->getLocalKey()
+            );
+        } else {
+            return Configuration::forSymmetricSigner(
+                new Signer\Ecdsa\Sha256(),
+                $this->getLocalKey()
+            );
+        }
     }
 
     /**

--- a/test/src/Provider/AppleTest.php
+++ b/test/src/Provider/AppleTest.php
@@ -5,6 +5,7 @@ namespace League\OAuth2\Client\Test\Provider;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
 use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Key;
 use League\OAuth2\Client\Provider\Apple;
 use League\OAuth2\Client\Provider\AppleResourceOwner;
 use League\OAuth2\Client\Token\AccessToken;
@@ -244,5 +245,13 @@ class AppleTest extends TestCase
         $this->assertEquals('123.4.567', $data->getId());
         $this->assertFalse($data->isPrivateEmail());
         $this->assertArrayHasKey('name', $data->toArray());
+    }
+
+    public function testGetConfiguration()
+    {
+        $provider = m::mock(Apple::class)->makePartial();
+        $provider->shouldReceive('getLocalKey')->andReturn(m::mock(Key::class));
+
+        $this->assertInstanceOf(Configuration::class, $provider->getConfiguration());
     }
 }


### PR DESCRIPTION
The specific combination of lcobucci/jwt ^3.4 and php 7.4 failed. The existing scenarios didn't catch that, since ^4.0 is allowed in php 7.4, however in our project some other package is not compatible with ^4.0, which resulted in the failure as mentioned.

Fixes #24