### PR TITLE
Moved fetching Apple JWT keys from token to provider

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -3,6 +3,7 @@
 namespace League\OAuth2\Client\Provider;
 
 use Exception;
+use Firebase\JWT\JWK;
 use InvalidArgumentException;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Signer\Key\LocalFileReference;
@@ -77,7 +78,21 @@ class Apple extends AbstractProvider
      */
     protected function createAccessToken(array $response, AbstractGrant $grant)
     {
-        return new AppleAccessToken($this->getHttpClient(), $response);
+        return new AppleAccessToken($this->getAppleKeys(), $response);
+    }
+
+    /**
+     * @return string[] Apple's JSON Web Keys
+     */
+    private function getAppleKeys()
+    {
+        $response = $this->httpClient->request('GET', 'https://appleid.apple.com/auth/keys');
+
+        if ($response) {
+            return JWK::parseKeySet(json_decode($response->getBody()->getContents(), true));
+        }
+
+        return [];
     }
 
     /**

--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -25,31 +25,23 @@ class AppleAccessToken extends AccessToken
     protected $isPrivateEmail;
 
     /**
-     * @var ClientInterface
-     */
-    protected $httpClient;
-
-    /**
      * Constructs an access token.
      *
-     * @param ClientInterface $httpClient the http client to use
+     * @param string[] $keys Valid Apple JWT keys
      * @param array $options An array of options returned by the service provider
      *     in the access token request. The `access_token` option is required.
      * @throws InvalidArgumentException if `access_token` is not provided in `$options`.
      *
      * @throws \Exception
      */
-    public function __construct($httpClient, array $options = [])
+    public function __construct(array $keys, array $options = [])
     {
-        $this->httpClient = $httpClient;
-
         if (array_key_exists('refresh_token', $options)) {
             if (empty($options['id_token'])) {
                 throw new InvalidArgumentException('Required option not passed: "id_token"');
             }
 
             $decoded = null;
-            $keys = $this->getAppleKey();
             $last = end($keys);
             foreach ($keys as $key) {
                 try {
@@ -86,20 +78,6 @@ class AppleAccessToken extends AccessToken
         if (isset($options['email'])) {
             $this->email = $options['email'];
         }
-    }
-
-    /**
-     * @return array Apple's JSON Web Key
-     */
-    protected function getAppleKey()
-    {
-        $response = $this->httpClient->request('GET', 'https://appleid.apple.com/auth/keys');
-
-        if ($response) {
-            return JWK::parseKeySet(json_decode($response->getBody()->getContents(), true));
-        }
-
-        return [];
     }
 
     /**

--- a/test/src/Token/AppleAccessTokenTest.php
+++ b/test/src/Token/AppleAccessTokenTest.php
@@ -23,12 +23,7 @@ class AppleAccessTokenTest extends TestCase
                 'sub' => '123.abc.123'
             ]);
 
-        $externalJWKMock = m::mock('overload:Firebase\JWT\JWK');
-        $externalJWKMock->shouldReceive('parseKeySet')
-            ->once()
-            ->andReturn(['examplekey']);
-
-        $accessToken = new AppleAccessToken($this->getClient(1), [
+        $accessToken = new AppleAccessToken(['examplekey'], [
             'access_token' => 'access_token',
             'token_type' => 'Bearer',
             'expires_in' => 3600,
@@ -42,7 +37,7 @@ class AppleAccessTokenTest extends TestCase
 
     public function testCreatingRefreshToken()
     {
-        $refreshToken = new AppleAccessToken($this->getClient(0), [
+        $refreshToken = new AppleAccessToken([], [
             'access_token' => 'access_token',
             'token_type' => 'Bearer',
             'expires_in' => 3600


### PR DESCRIPTION
Since AccessToken is serialized in specific set-ups, existence of the httpClient leads to problems, since closures are not serializable. Also, it's not necessary to keep the httpClient there, since it's only used in the constructor.

Fixes #26, #28