### PR TITLE
Support for `firebase/php-jwt` Version 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,16 @@
         "sign-in-with-apple"
     ],
     "require": {
-        "league/oauth2-client": "^2.0",
         "ext-json": "*",
-        "firebase/php-jwt": "^5.2",
+        "league/oauth2-client": "^2.0",
+        "firebase/php-jwt": "^6.0",
         "lcobucci/jwt": "^3.4 || ^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.0 || ^9.3",
         "mockery/mockery": "^1.3",
         "php-parallel-lint/php-parallel-lint": "^1.3",
-        "squizlabs/php_codesniffer": "^2.3 || ^3.0",
-        "ext-json": "*"
+        "squizlabs/php_codesniffer": "^2.3 || ^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -6,7 +6,7 @@ use Exception;
 use Firebase\JWT\JWK;
 use InvalidArgumentException;
 use Lcobucci\JWT\Configuration;
-use Lcobucci\JWT\Signer\Key\LocalFileReference;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Key;
 use League\OAuth2\Client\Grant\AbstractGrant;
@@ -252,17 +252,14 @@ class Apple extends AbstractProvider
      */
     public function getConfiguration()
     {
-        if (method_exists(Signer\Ecdsa\Sha256::class, 'create')) {
-            return Configuration::forSymmetricSigner(
-                Signer\Ecdsa\Sha256::create(),
-                $this->getLocalKey()
-            );
-        } else {
-            return Configuration::forSymmetricSigner(
-                new Signer\Ecdsa\Sha256(),
-                $this->getLocalKey()
-            );
+        if (!method_exists(Signer\Ecdsa\Sha256::class, 'create')) {
+            throw new Exception('Cannot create Ecdsa\Sha256 configuration');
         }
+
+        return Configuration::forSymmetricSigner(
+            Signer\Ecdsa\Sha256::create(),
+            $this->getLocalKey()
+        );
     }
 
     /**
@@ -270,6 +267,6 @@ class Apple extends AbstractProvider
      */
     public function getLocalKey()
     {
-        return LocalFileReference::file($this->keyFilePath);
+        return InMemory::file($this->keyFilePath);
     }
 }

--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -26,7 +26,7 @@ class AppleAccessToken extends AccessToken
     /**
      * Constructs an access token.
      *
-     * @param string[] $keys Valid Apple JWT keys
+     * @param Key[] $keys Valid Apple JWT keys
      * @param array $options An array of options returned by the service provider
      *     in the access token request. The `access_token` option is required.
      * @throws InvalidArgumentException if `access_token` is not provided in `$options`.
@@ -44,7 +44,7 @@ class AppleAccessToken extends AccessToken
             $last = end($keys);
             foreach ($keys as $key) {
                 try {
-                    $decoded = JWT::decode($options['id_token'], new Key($key, 'RS256'));
+                    $decoded = JWT::decode($options['id_token'], $key);
                     break;
                 } catch (\Exception $exception) {
                     if ($last === $key) {

--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -2,9 +2,8 @@
 
 namespace League\OAuth2\Client\Token;
 
-use Firebase\JWT\JWK;
 use Firebase\JWT\JWT;
-use GuzzleHttp\ClientInterface;
+use Firebase\JWT\Key;
 use InvalidArgumentException;
 
 class AppleAccessToken extends AccessToken
@@ -45,7 +44,7 @@ class AppleAccessToken extends AccessToken
             $last = end($keys);
             foreach ($keys as $key) {
                 try {
-                    $decoded = JWT::decode($options['id_token'], $key, ['RS256']);
+                    $decoded = JWT::decode($options['id_token'], new Key($key, 'RS256'));
                     break;
                 } catch (\Exception $exception) {
                     if ($last === $key) {

--- a/test/src/Token/AppleAccessTokenTest.php
+++ b/test/src/Token/AppleAccessTokenTest.php
@@ -72,11 +72,11 @@ class AppleAccessTokenTest extends TestCase
     public function testCreatingAccessTokenFailsBecauseNoDecodingIsPossible()
     {
         $this->expectException('\Exception');
-        $this->expectExceptionMessage('arguments matched no expected argument list for this method');
+        $this->expectExceptionMessage('Got no data within "id_token"!');
 
         $externalJWTMock = m::mock('overload:Firebase\JWT\JWT');
         $externalJWTMock->shouldReceive('decode')
-            ->with('something', new Key('examplekey', 'RS256'))
+            ->with('something', 'examplekey')
             ->once()
             ->andReturnNull();
 

--- a/test/src/Token/AppleAccessTokenTest.php
+++ b/test/src/Token/AppleAccessTokenTest.php
@@ -17,7 +17,7 @@ class AppleAccessTokenTest extends TestCase
     {
         $externalJWTMock = m::mock('overload:Firebase\JWT\JWT');
         $externalJWTMock->shouldReceive('decode')
-            ->with('something', 'examplekey', ['RS256'])
+            ->with('something', 'examplekey')
             ->once()
             ->andReturn([
                 'sub' => '123.abc.123',
@@ -38,6 +38,8 @@ class AppleAccessTokenTest extends TestCase
         $this->assertEquals('access_token', $accessToken->getToken());
         $this->assertEquals('john@doe.com', $accessToken->getEmail());
         $this->assertTrue($accessToken->isPrivateEmail());
+
+        $this->assertTrue(true);
     }
 
     public function testCreateFailsBecauseNoIdTokenIsSet()

--- a/test/src/Token/AppleAccessTokenTest.php
+++ b/test/src/Token/AppleAccessTokenTest.php
@@ -2,6 +2,7 @@
 
 namespace League\OAuth2\Client\Test\Token;
 
+use Firebase\JWT\Key;
 use League\OAuth2\Client\Token\AppleAccessToken;
 use PHPUnit\Framework\TestCase;
 use Mockery as m;
@@ -69,11 +70,11 @@ class AppleAccessTokenTest extends TestCase
     public function testCreatingAccessTokenFailsBecauseNoDecodingIsPossible()
     {
         $this->expectException('\Exception');
-        $this->expectExceptionMessage('Got no data within "id_token"!');
+        $this->expectExceptionMessage('arguments matched no expected argument list for this method');
 
         $externalJWTMock = m::mock('overload:Firebase\JWT\JWT');
         $externalJWTMock->shouldReceive('decode')
-            ->with('something', 'examplekey', ['RS256'])
+            ->with('something', new Key('examplekey', 'RS256'))
             ->once()
             ->andReturnNull();
 


### PR DESCRIPTION
This fixes #31 and upgrades support for `firebase/php-jwt` in Version 6, but renders previous versions of it unusable.

Also fixed deprecation errors regarding `LocalFileReference` while at it.

All tests pass.

Edit: This also fixes the issue in #30 