### PR TITLE
Improve token construction logic and change key getter to public

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -84,7 +84,7 @@ class Apple extends AbstractProvider
     /**
      * @return string[] Apple's JSON Web Keys
      */
-    private function getAppleKeys()
+    public function getAppleKeys()
     {
         $response = $this->httpClient->request('GET', 'https://appleid.apple.com/auth/keys');
 

--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -35,11 +35,8 @@ class AppleAccessToken extends AccessToken
      */
     public function __construct(array $keys, array $options = [])
     {
-        if (array_key_exists('refresh_token', $options)) {
-            if (empty($options['id_token'])) {
-                throw new InvalidArgumentException('Required option not passed: "id_token"');
-            }
-
+        if (array_key_exists('id_token', $options)) {
+            $this->idToken = $options['id_token'];
             $decoded = null;
             $last = end($keys);
             foreach ($keys as $key) {
@@ -71,16 +68,11 @@ class AppleAccessToken extends AccessToken
                 $this->isPrivateEmail = $payload['is_private_email'];
             }
         }
-
-        parent::__construct($options);
-
-        if (isset($options['id_token'])) {
-            $this->idToken = $options['id_token'];
-        }
-
-        if (isset($options['email'])) {
+        else if (isset($options['email'])) {
             $this->email = $options['email'];
         }
+
+        parent::__construct($options);
     }
 
     /**


### PR DESCRIPTION
Thanks for this package; Apple is pretty frustrating in that they kinda look like OAuth but their implementation is, well, wacky!

I am in a situation where I am doing both native app sign-in with Apple (because it's required...) as well as supporting sign-in with Apple on the web. Because their implementation _looks_ like OpenID Connect but they don't support a user info endpoint, I'm passing the web back-end the ID token (a JWS) and using that to extract out the user's identity. This is done via a token exchange grant.

Anyway, I needed a way to construct an access token object using the ID token, and found that 1) the docblock on the constructor didn't reflect the true data requirements of the method and 2) it would be helpful to be able to fetch the Apple JWK set outside of the provider.

This PR addresses both points, which I think help make this package more syntactically correct and useful.

Admittedly this is a bit of a drive-by contribution but if this looks good in spirit, I can make whatever adjustments you'd like, e.g. test coverage. I'm not quite sure this requires _new_ coverage?