### PR TITLE
Fix Apple key retrieval when using Guzzle logging

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -89,7 +89,7 @@ class Apple extends AbstractProvider
         $response = $this->httpClient->request('GET', 'https://appleid.apple.com/auth/keys');
 
         if ($response && $response->getStatusCode() === 200) {
-            return JWK::parseKeySet(json_decode($response->getBody()->getContents(), true));
+            return JWK::parseKeySet(json_decode($response->getBody()->__toString(), true));
         }
 
         return [];


### PR DESCRIPTION
When using Guzzle logging to log a message body the stream is not reset to
the start, causing future calls to getContents() to be empty. It seems
recommended way of getting the body as a string is to use `__toString()`
(https://github.com/guzzle/guzzle/pull/1842)