### PR TITLE
Update Apple.php

### DIFF
--- a/src/Provider/Apple.php
+++ b/src/Provider/Apple.php
@@ -183,7 +183,7 @@ class Apple extends AbstractProvider
      *
      * @return array
      */
-    protected function getDefaultScopes()
+    public function getDefaultScopes()
     {
         return $this->defaultScopes;
     }


### PR DESCRIPTION
The method is declared as public in AbstractProvider and any other provider and throws an error if it is protected. If we use this plugin together with bigfork/silverstripe-oauth it works only if the method is public.