### PR TITLE
Fix: handle different JWT::decode signatures

### DIFF
--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -50,8 +50,7 @@ class AppleAccessToken extends AccessToken
                         $decodeMethodReflection = new \ReflectionMethod(JWT::class, 'decode');
                         $decodeMethodParameters = $decodeMethodReflection->getParameters();
                         // Backwards compatibility for firebase/php-jwt >=5.2.0 <=5.5.1 supported by PHP 5.6
-                        if (
-                            array_key_exists(2, $decodeMethodParameters) &&
+                        if (array_key_exists(2, $decodeMethodParameters) &&
                             'allowed_algs' === $decodeMethodParameters[2]->getName()
                         ) {
                             $decoded = JWT::decode($options['id_token'], $key, ['RS256']);

--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -47,7 +47,15 @@ class AppleAccessToken extends AccessToken
                     try {
                         $decoded = JWT::decode($options['id_token'], $key);
                     } catch (\UnexpectedValueException $e) {
-                        $decoded = JWT::decode($options['id_token'], $key, ['RS256']);
+                        $decodeMethodReflection = new \ReflectionMethod(JWT::class, 'decode');
+                        $decodeMethodParameters = $decodeMethodReflection->getParameters();
+                        // Backwards compatibility for firebase/php-jwt >=5.2.0 <=5.5.1 supported by PHP 5.6
+                        if (array_key_exists(2, $decodeMethodParameters) && 'allowed_algs' === $decodeMethodParameters[2]->getName()) {
+                            $decoded = JWT::decode($options['id_token'], $key, ['RS256']);
+                        } else {
+                            $headers = (object) ['alg' => 'RS256'];
+                            $decoded = JWT::decode($options['id_token'], $key, $headers);
+                        }
                     }
                     break;
                 } catch (\Exception $exception) {

--- a/src/Token/AppleAccessToken.php
+++ b/src/Token/AppleAccessToken.php
@@ -50,7 +50,10 @@ class AppleAccessToken extends AccessToken
                         $decodeMethodReflection = new \ReflectionMethod(JWT::class, 'decode');
                         $decodeMethodParameters = $decodeMethodReflection->getParameters();
                         // Backwards compatibility for firebase/php-jwt >=5.2.0 <=5.5.1 supported by PHP 5.6
-                        if (array_key_exists(2, $decodeMethodParameters) && 'allowed_algs' === $decodeMethodParameters[2]->getName()) {
+                        if (
+                            array_key_exists(2, $decodeMethodParameters) &&
+                            'allowed_algs' === $decodeMethodParameters[2]->getName()
+                        ) {
                             $decoded = JWT::decode($options['id_token'], $key, ['RS256']);
                         } else {
                             $headers = (object) ['alg' => 'RS256'];


### PR DESCRIPTION
This PR provides a solution for #46 caused by different signatures of `JWT::decode` function in the different supported versions of `firebase/php-jwt` 

This solution has been suggested by @Kreyu in #50 

If tests pass and this PR is merged then #51 , #47 and #50 can safely be closed