### PR TITLE
chore(deps): bump firebase/php-jwt to ^5.2 || ^6.0 || ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "ext-json": "*",
         "league/oauth2-client": "^2.0",
-        "firebase/php-jwt": "^5.2 || ^6.0",
+        "firebase/php-jwt": "^5.2 || ^6.0 || ^7.0",
         "lcobucci/jwt": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Description
Possibility of using firebase/php-jwt version 7.
In [version 7 of firebase/php-jwt](https://github.com/firebase/php-jwt/releases/tag/v7.0.0), there is a [breaking change](https://github.com/firebase/php-jwt/pull/613) in the sign method of the JWT object.
This method is not used in this project.